### PR TITLE
Simplify constructor

### DIFF
--- a/mock.go
+++ b/mock.go
@@ -13,7 +13,11 @@ const Anything = mock.Anything
 // Mock takes a T interface type and returns a runtime generated mock implementation for it
 // plus a testify mock.Mock object to control its behavior
 func Mock[T any]() (T, *mock.Mock) {
-	typ, methods := getInterfaceTypeAndMethods[T]()
+	typ := reflect.TypeOf((*T)(nil)).Elem()
+	if typ.Kind() != reflect.Interface {
+		panic("not an interface type: " + typ.Name())
+	}
+
 	mockTyp := reflect.StructOf([]reflect.StructField{
 		{
 			Name: "IcallBase__" + typ.Name(),
@@ -32,10 +36,10 @@ func Mock[T any]() (T, *mock.Mock) {
 	getMock := func(t reflect.Value) *mock.Mock {
 		return t.Field(1).Interface().(*mock.Mock)
 	}
-	methodInfos := make(icallBase, len(methods))
+	methodInfos := make(icallBase, typ.NumMethod())
 	abiMethods := getAbiMethods(mockTyp)
-	for i, method := range methods {
-		methodInfos[i] = newMethodInfo(mockTyp, method)
+	for i := range methodInfos {
+		methodInfos[i] = newMethodInfo(mockTyp, typ.Method(i))
 		abiMethods[i].setFn(icall_array[i])
 	}
 
@@ -43,16 +47,4 @@ func Mock[T any]() (T, *mock.Mock) {
 	t.Field(0).Set(reflect.ValueOf(methodInfos))
 	t.Field(1).Set(reflect.ValueOf(new(mock.Mock)))
 	return t.Interface().(T), getMock(t)
-}
-
-func getInterfaceTypeAndMethods[T any]() (reflect.Type, []reflect.Method) {
-	typ := reflect.TypeOf((*T)(nil)).Elem()
-	if typ.Kind() != reflect.Interface {
-		panic("not an interface type: " + typ.Name())
-	}
-	methods := make([]reflect.Method, typ.NumMethod())
-	for i := range methods {
-		methods[i] = typ.Method(i)
-	}
-	return typ, methods
 }

--- a/mock.go
+++ b/mock.go
@@ -33,9 +33,8 @@ func Mock[T any]() (T, *mock.Mock) {
 			Anonymous: true,
 		},
 	})
-	getMock := func(t reflect.Value) *mock.Mock {
-		return t.Field(1).Interface().(*mock.Mock)
-	}
+
+	m := new(mock.Mock)
 	methodInfos := make(icallBase, typ.NumMethod())
 	abiMethods := getAbiMethods(mockTyp)
 	for i := range methodInfos {
@@ -45,6 +44,6 @@ func Mock[T any]() (T, *mock.Mock) {
 
 	t := reflect.New(mockTyp).Elem()
 	t.Field(0).Set(reflect.ValueOf(methodInfos))
-	t.Field(1).Set(reflect.ValueOf(new(mock.Mock)))
-	return t.Interface().(T), getMock(t)
+	t.Field(1).Set(reflect.ValueOf(m))
+	return t.Interface().(T), m
 }


### PR DESCRIPTION
Refactor the `Mock[T]()` constructor to simplify implementation.

Note: Just an early improvement while I'm reviewing the whole project.